### PR TITLE
Add spoiler indicator for missing planes

### DIFF
--- a/autospoilersD.js
+++ b/autospoilersD.js
@@ -50,4 +50,12 @@ setInterval(
         }
     },
 100)
-+
+
+setInterval(
+    function(){
+        if(["3292", "3054"].includes(geofs.aircraft.instance.id) && geofs.aircraft.instance.setup.instruments["spoilers"] === undefined){
+            geofs.aircraft.instance.setup.instruments["spoilers"] = "";
+            instruments.init(geofs.aircraft.instance.setup.instruments);
+        }
+    },
+500)


### PR DESCRIPTION
I have added spoiler indicators for b737-800 and p8, because they have spoilers, but they didn't have the correct instruments.